### PR TITLE
software: use rogue v6.14.0 and native pyrogue.pydm.runPyDM

### DIFF
--- a/software/scripts/devGui.py
+++ b/software/scripts/devGui.py
@@ -11,13 +11,13 @@
 import setupLibPaths
 import simple_rfsoc_4x2_example
 
-import os
 import sys
 import argparse
 import importlib
 import rogue
 import pyrogue
-import axi_soc_ultra_plus_core.rfsoc_utility.pydm
+import pyrogue.pydm
+from axi_soc_ultra_plus_core.rfsoc_utility.gui.GuiTop import GuiTop
 
 if __name__ == "__main__":
 
@@ -95,13 +95,15 @@ if __name__ == "__main__":
         # Development PyDM GUI
         ######################
         if (args.guiType == 'PyDM'):
-            axi_soc_ultra_plus_core.rfsoc_utility.pydm.runPyDM(
-                serverList = root.zmqServer.address,
-                ui       = f'{os.path.dirname(axi_soc_ultra_plus_core.rfsoc_utility.__file__)}/gui/GuiTop.py',
+            pyrogue.pydm.runPyDM(
+                serverList      = root.zmqServer.address,
+                display_factory = lambda parent=None, args=[], macros=None: GuiTop(
+                    parent   = parent,
+                    args     = args + ['numAdcCh=4', 'numDacCh=2'],
+                    macros   = macros,
+                ),
                 sizeX    = 800,
                 sizeY    = 800,
-                numAdcCh = 4,
-                numDacCh = 2,
             )
 
         #################

--- a/software/setup_env_slac.sh
+++ b/software/setup_env_slac.sh
@@ -6,4 +6,4 @@ source /sdf/group/faders/users/$USER/miniforge3/etc/profile.d/conda.sh
 ##################################
 # Activate Rogue conda Environment
 ##################################
-conda activate rogue_v6.12.0
+conda activate rogue_v6.14.0


### PR DESCRIPTION
## Summary

- Bump the conda environment in `setup_env_slac.sh` from `rogue_v6.12.0` to `rogue_v6.14.0`.
- Switch the `devGui.py` PyDM launch to rogue's native `pyrogue.pydm.runPyDM` object-based API ([slaclab/rogue#1136](https://github.com/slaclab/rogue/pull/1136)) instead of the file-path-based `axi_soc_ultra_plus_core.rfsoc_utility.pydm.runPyDM` wrapper.

## Details

`GuiTop` is now constructed directly via `display_factory`. Because the native `runPyDM` only forwards `sizeX/sizeY/title/maxListExpand/maxListSize` into the display args (not `numAdcCh`/`numDacCh`), the factory appends `numAdcCh=4`/`numDacCh=2` itself so `GuiTop` still builds the 4 ADC / 2 DAC waveform tabs.

Removed the now-orphaned `import os` (previously used only by the old `ui=` f-string path).

## Testing

Verified on real hardware (RFSoC 4x2 at 10.0.0.156):
- rogue v6.14.0 active; `runPyDM` exposes `display_factory`.
- `python scripts/devGui.py --ip 10.0.0.156` connects, initializes RFDC, loads `defaults.yml`, and constructs `GuiTop` via the factory with no errors.
- User confirmed the GUI works.